### PR TITLE
Added separate experience bar setting to 'constants.asm'.

### DIFF
--- a/color/color.asm
+++ b/color/color.asm
@@ -74,7 +74,7 @@ BuildBattlePalPacket:
 	ld e,3
 	callba LoadSGBPalette
 
-IF GEN_2_GRAPHICS
+IF GEN_2_EXP_BAR
 	; Player exp bar
 	ld d, PAL_EXP
 ELSE
@@ -146,7 +146,7 @@ ENDC
 	dec b
 	jr nz,.eDrawLine
 
-IF GEN_2_GRAPHICS
+IF GEN_2_EXP_BAR
 	; Player exp bar
 	ld hl, W2_TilesetPaletteMap + 10 + 11 * 20
 	ld b, 8

--- a/constants.asm
+++ b/constants.asm
@@ -1,5 +1,5 @@
 GEN_2_GRAPHICS	EQU 1
-
+GEN_2_EXP_BAR	EQU 1
 INCLUDE "macros.asm"
 
 INCLUDE "hram.asm"

--- a/engine/battle/15.asm
+++ b/engine/battle/15.asm
@@ -150,7 +150,7 @@ GainExperience: ; 5524f (15:524f)
 	call PrintText
 	xor a ; party mon data
 	ld [wcc49], a
-IF GEN_2_GRAPHICS
+IF GEN_2_EXP_BAR
 	call AnimateEXPBar
 ELSE
 	call LoadMonData
@@ -164,7 +164,7 @@ ENDC
 	ld a, [hl] ; current level
 	cp d
 	jp z, .nextMon ; if level didn't change, go to next mon
-IF GEN_2_GRAPHICS
+IF GEN_2_EXP_BAR
 	call KeepEXPBarFull
 ELSE
 	ld a, [W_CURENEMYLVL]
@@ -252,7 +252,7 @@ ENDC
 	call PrintText
 	xor a ; party mon data
 	ld [wcc49], a
-IF GEN_2_GRAPHICS
+IF GEN_2_EXP_BAR
 	call AnimateEXPBarAgain
 ELSE
 	call LoadMonData

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -1894,7 +1894,7 @@ DrawPlayerHUDAndHPBar: ; 3cd60 (f:4d60)
 	ld [hl], $73
 	ld de, wBattleMonNick
 	hlCoord 10, 7
-IF GEN_2_GRAPHICS
+IF GEN_2_EXP_BAR
 	call PlaceString
 	call PrintEXPBar
 ELSE
@@ -8721,7 +8721,7 @@ LoadMonBackSpriteHook: ; HAX
 	ld c,a
 	jp LoadUncompressedSpriteData
 
-IF GEN_2_GRAPHICS
+IF GEN_2_EXP_BAR
 PrintEXPBar:
 	call CalcEXPBarPixelLength
 	ld a, [H_QUOTIENT + 3] ; pixel length

--- a/home.asm
+++ b/home.asm
@@ -3180,7 +3180,7 @@ LoadTextBoxTilePatterns::
 
 ; copies HP bar and status display tile patterns into VRAM
 LoadHpBarAndStatusTilePatterns:: ; 36c0 (0:36c0)
-IF GEN_2_GRAPHICS
+IF GEN_2_EXP_BAR
 	callba LoadHPBarAndEXPBar
 	ret
 	ds $17

--- a/main.asm
+++ b/main.asm
@@ -2054,7 +2054,7 @@ GotPalID:
 	ld [rSVBK],a
 	ret
 
-IF GEN_2_GRAPHICS
+IF GEN_2_EXP_BAR
 LoadHPBarAndEXPBar:
 	ld de,HpBarAndStatusGraphics
 	ld hl,vChars2 + $620
@@ -4973,7 +4973,7 @@ INCLUDE "engine/items/tms.asm"
 INCLUDE "engine/battle/4_2.asm"
 INCLUDE "engine/random.asm"
 
-IF GEN_2_GRAPHICS
+IF GEN_2_EXP_BAR
 EXPBarGraphics:  INCBIN "gfx/gs/exp_bar.2bpp"
 ENDC
 
@@ -6121,7 +6121,7 @@ INCLUDE "engine/menu/diploma.asm"
 
 INCLUDE "engine/overworld/trainers.asm"
 
-IF GEN_2_GRAPHICS
+IF GEN_2_EXP_BAR
 INCLUDE "engine/battle/exp_bar.asm"
 ENDC
 

--- a/wram.asm
+++ b/wram.asm
@@ -2098,7 +2098,7 @@ wBoxMonOT::    ds 11 * MONS_PER_BOX ; dd2a
 wBoxMonNicks:: ds 11 * MONS_PER_BOX ; de06
 wBoxMonNicksEnd:: ; dee2
 
-IF GEN_2_GRAPHICS
+IF GEN_2_EXP_BAR
 wEXPBarPixelLength::  ds 1
 wEXPBarBaseEXP::      ds 3
 wEXPBarCurEXP::       ds 3


### PR DESCRIPTION
I wanted to be able to use the old style pokemon red/blue sprites with the experience bar, which I see as a welcome improvement. So I added a second option to `constants.asm` called `GEN_2_EXP_BAR`.

I have not encountered any problems resulting from my changes.
