### PR TITLE
Fix a remaining hardcoded ROM0 address call

### DIFF
--- a/color/refreshmaps.asm
+++ b/color/refreshmaps.asm
@@ -40,7 +40,7 @@ label_2c_l001:
 	ld [hli],a
 	dec c
 	jr nz,label_2c_l000
-	jp $1ee9
+	jp ReturnPoint
 
 	ORG $2c, $7080
 label_2c_l002:
@@ -55,7 +55,7 @@ label_2c_l003:
 	ld [hli],a
 	dec c
 	jr nz,label_2c_l002
-	jp $1ee9
+	jp ReturnPoint
 
 SECTION "bank2F",ROMX,BANK[$2F]
 

--- a/home/vcopy.asm
+++ b/home/vcopy.asm
@@ -296,7 +296,7 @@ UpdateMovingBgTiles::
 	cp 20
 	ret c
 	cp 21
-	jr z, .flower
+	jr z, FlowerTiles
 
 ; water
 
@@ -317,6 +317,7 @@ UpdateMovingBgTiles::
 	jp nz,label_2c_l000
 	jp label_2c_l002
 
+ReturnPoint::
 	ld a,[H_LOADEDROMBANK]
 	ld [MBC1RomBank],a
 
@@ -328,7 +329,7 @@ UpdateMovingBgTiles::
 	ld [hMovingBGTilesCounter1], a
 	ret
 
-.flower
+FlowerTiles:
 	xor a
 	ld [hMovingBGTilesCounter1], a
 


### PR DESCRIPTION
Noticed this a while back, finally got around to fixing it. There was no label here originally, but I found the right address and added one, then had to update another label accordingly to not use the . notation, for obvious reasons.