### PR TITLE
Fix healing machine pokeballs in Indigo plateau lobby and slots machines

### DIFF
--- a/color/color.asm
+++ b/color/color.asm
@@ -453,7 +453,10 @@ SetPal_Slots:
 
 	xor a
 	ldh [rSVBK], a
-	ret
+	
+	; Wait 3 frames to allow tilemap updates to apply. Prevents garbage
+	; Prevents garbage from appearing when the slots machine open.
+	jp Delay3
 
 ; Titlescreen with cycling pokemon
 SetPal_TitleScreen:

--- a/color/sprites.asm
+++ b/color/sprites.asm
@@ -38,6 +38,9 @@ LoadOverworldSpritePalettes:
 	ld hl, SpritePalettesPokecenter
 	cp POKECENTER
 	jr z, .gotPaletteList
+	ld a, [wCurMap]
+	cp INDIGO_PLATEAU_LOBBY
+	jr z, .gotPaletteList
 	; If not, load the normal Object Pals
 	ld hl, SpritePalettes
 .gotPaletteList


### PR DESCRIPTION
Pokeballs now have the correct color instead of the default purple
Fix slots machine