### PR TITLE
Organizing Home Bank For Space Usage

### DIFF
--- a/home/bankswitch.asm
+++ b/home/bankswitch.asm
@@ -33,3 +33,19 @@ Bankswitch::
 	ldh [hLoadedROMBank], a
 	ld [MBC1RomBank], a
 	ret
+
+
+SetRomBank::
+	ldh [hLoadedROMBank], a
+	ld [MBC1RomBank], a
+	ret
+
+_LoadMapVramAndColors:
+	ldh a, [hLoadedROMBank]
+	push af
+	ld a, BANK(LoadMapVramAndColors)
+	ld [MBC1RomBank], a
+	call LoadMapVramAndColors
+	pop af
+	ld [MBC1RomBank], a
+	ret

--- a/home/header.asm
+++ b/home/header.asm
@@ -1,15 +1,12 @@
 SECTION "rst0", ROM0[$0000]
-_LoadMapVramAndColors:
-	ldh a, [hLoadedROMBank]
-	push af
-	ld a, BANK(LoadMapVramAndColors)
-	ld [MBC1RomBank], a
-	call LoadMapVramAndColors
-	pop af
-	ld [MBC1RomBank], a
-	ret
+	rst $38
 
-;SECTION "rst8", ROM0[$0008]
+	ds $08 - @, 0 ; unused
+
+SECTION "rst8", ROM0[$0008]
+	rst $38
+
+	ds $10 - @, 0 ; unused
 
 ; HAX: rst10 is used for the vblank hook
 SECTION "rst10", ROM0[$0010]
@@ -21,13 +18,25 @@ SECTION "rst10", ROM0[$0010]
 SECTION "rst18", ROM0[$0018]
 	jp Bankswitch
 
-; memory for rst vectors $20-$38 used by color hack
+SECTION "rst20", ROM0[$0020]
+	rst $38
 
-SetRomBank::
-	ldh [hLoadedROMBank], a
-	ld [MBC1RomBank], a
-	ret
+	ds $28 - @, 0 ; unused
 
+SECTION "rst28", ROM0[$0028]
+	rst $38
+
+	ds $30 - @, 0 ; unused
+
+SECTION "rst30", ROM0[$0030]
+	rst $38
+
+	ds $38 - @, 0 ; unused
+
+SECTION "rst38", ROM0[$0038]
+	rst $38
+
+	ds $40 - @, 0 ; unused
 
 ; Game Boy hardware interrupts
 

--- a/layout.link
+++ b/layout.link
@@ -3,20 +3,20 @@ ROM0
 	"NULL"
 	org $0000
 	"rst0"
-;	org $0008
-;	"rst8"
+	org $0008
+	"rst8"
 	org $0010
 	"rst10"
 	org $0018
 	"rst18"
-;	org $0020
-;	"rst20"
-;	org $0028
-;	"rst28"
-;	org $0030
-;	"rst30"
-;	org $0038
-;	"rst38"
+	org $0020
+	"rst20"
+	org $0028
+	"rst28"
+	org $0030
+	"rst30"
+	org $0038
+	"rst38"
 	org $0040
 	"vblank"
 	org $0048


### PR DESCRIPTION
- LoadMapVramColors and SetRomBank moved to banswitch file since they need to be in Home Bank, but frees up space in Header
- Remove "; memory for rst vectors $20-$38 used by color hack" since it was stated this doesn't apply anymore since the rom isnt binary now.
- Restored RST Sections 0, 8, 20, 28, 30, 38 to be used for RST Vectors (if necessary)
- Restored RST Sections in Layout as well

Engezerstorung was a big help for optimizing space in Header as well.